### PR TITLE
[SET-870] Compare build IDs not versions of artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,10 @@
         <version.com.fasterxml.jackson>2.17.0</version.com.fasterxml.jackson>
         <version.info.picocli>4.7.5</version.info.picocli>
         <version.org.jboss.pnc>2.7.3</version.org.jboss.pnc>
+        <version.org.assertj>3.26.3</version.org.assertj>
         <version.org.junit>5.10.2</version.org.junit>
-        <version.org.wildfly.channel>1.1.0.Final</version.org.wildfly.channel>
+        <version.org.mockito>5.14.2</version.org.mockito>
+        <version.org.wildfly.channel>1.2.1.Final</version.org.wildfly.channel>
     </properties>
 
     <dependencyManagement>
@@ -53,15 +55,34 @@
                 <version>${version.org.jboss.pnc}</version>
             </dependency>
             <dependency>
+                <groupId>org.wildfly.channel</groupId>
+                <artifactId>channel-core</artifactId>
+                <version>${version.org.wildfly.channel}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${version.org.junit}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.wildfly.channel</groupId>
-                <artifactId>channel-core</artifactId>
-                <version>${version.org.wildfly.channel}</version>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.org.mockito}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${version.org.mockito}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.org.assertj}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -81,13 +102,29 @@
             <artifactId>rest-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.channel</groupId>
+            <artifactId>channel-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.channel</groupId>
-            <artifactId>channel-core</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jboss/set/components/BuildCache.java
+++ b/src/main/java/org/jboss/set/components/BuildCache.java
@@ -1,0 +1,69 @@
+package org.jboss.set.components;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.set.components.pnc.PncBuild;
+import org.jboss.set.components.pnc.PncComponent;
+
+class BuildCache {
+    final Map<Key, Entry> cache = new ConcurrentHashMap<>();
+
+    static Key toKey(String... parts) {
+        return new Key(parts);
+    }
+
+    void cache(Key key, PncComponent componentName, PncBuild.Id buildId) {
+        cache.put(key, new Entry(componentName, buildId));
+    }
+
+    Entry get(Key key) {
+        return cache.get(key);
+    }
+
+    boolean contains(Key key) {
+        return cache.containsKey(key);
+    }
+
+    static class Key {
+        private final String key;
+
+        Key(String... parts) {
+            this.key = StringUtils.join(parts, ":");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Key that = (Key) o;
+            return Objects.equals(key, that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key);
+        }
+    }
+
+
+    static class Entry {
+        private final PncBuild.Id buildId;
+        private final PncComponent componentName;
+
+        public Entry(PncComponent componentName, PncBuild.Id buildId) {
+            this.buildId = buildId;
+            this.componentName = componentName;
+        }
+
+        public PncBuild.Id getBuildId() {
+            return buildId;
+        }
+
+        public PncComponent getComponentName() {
+            return componentName;
+        }
+    }
+}

--- a/src/main/java/org/jboss/set/components/Violation.java
+++ b/src/main/java/org/jboss/set/components/Violation.java
@@ -4,6 +4,7 @@ import org.wildfly.channel.ArtifactCoordinate;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class Violation {
 
@@ -33,5 +34,26 @@ public class Violation {
             }
         }
         return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return "Violation{" +
+                "componentName='" + componentName + '\'' +
+                ", artifactsByVersion=" + artifactsByVersion +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Violation violation = (Violation) o;
+        return Objects.equals(componentName, violation.componentName) && Objects.equals(artifactsByVersion, violation.artifactsByVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(componentName, artifactsByVersion);
     }
 }

--- a/src/main/java/org/jboss/set/components/Warning.java
+++ b/src/main/java/org/jboss/set/components/Warning.java
@@ -30,4 +30,12 @@ public class Warning {
 
         return sb.toString();
     }
+
+    @Override
+    public String toString() {
+        return "Warning{" +
+                "message='" + message + '\'' +
+                ", artifactCoordinates=" + artifactCoordinates +
+                '}';
+    }
 }

--- a/src/main/java/org/jboss/set/components/pnc/PncArtifact.java
+++ b/src/main/java/org/jboss/set/components/pnc/PncArtifact.java
@@ -1,5 +1,7 @@
 package org.jboss.set.components.pnc;
 
+import java.util.Objects;
+
 import org.wildfly.channel.ArtifactCoordinate;
 
 public class PncArtifact {
@@ -52,6 +54,19 @@ public class PncArtifact {
             return "Id{" +
                     "id='" + id + '\'' +
                     '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Id id1 = (Id) o;
+            return Objects.equals(id, id1.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
         }
     }
 }

--- a/src/main/java/org/jboss/set/components/pnc/PncBuild.java
+++ b/src/main/java/org/jboss/set/components/pnc/PncBuild.java
@@ -1,5 +1,7 @@
 package org.jboss.set.components.pnc;
 
+import java.util.Objects;
+
 public class PncBuild {
 
     private final PncBuild.Id id;
@@ -42,6 +44,19 @@ public class PncBuild {
             return "Id{" +
                     "id='" + id + '\'' +
                     '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Id id1 = (Id) o;
+            return Objects.equals(id, id1.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
         }
     }
 }

--- a/src/main/java/org/jboss/set/components/pnc/PncBuild.java
+++ b/src/main/java/org/jboss/set/components/pnc/PncBuild.java
@@ -5,9 +5,9 @@ import java.util.Objects;
 public class PncBuild {
 
     private final PncBuild.Id id;
-    private final String brewComponent;
+    private final PncComponent brewComponent;
 
-    public PncBuild(Id id, String brewComponent) {
+    public PncBuild(Id id, PncComponent brewComponent) {
         this.id = id;
         this.brewComponent = brewComponent;
     }
@@ -16,7 +16,7 @@ public class PncBuild {
         return id;
     }
 
-    public String getBrewComponent() {
+    public PncComponent getBrewComponent() {
         return brewComponent;
     }
 

--- a/src/main/java/org/jboss/set/components/pnc/PncComponent.java
+++ b/src/main/java/org/jboss/set/components/pnc/PncComponent.java
@@ -1,0 +1,28 @@
+package org.jboss.set.components.pnc;
+
+import java.util.Objects;
+
+public class PncComponent {
+    private final String name;
+
+    public PncComponent(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PncComponent that = (PncComponent) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/src/main/java/org/jboss/set/components/pnc/PncManagerImpl.java
+++ b/src/main/java/org/jboss/set/components/pnc/PncManagerImpl.java
@@ -69,7 +69,7 @@ public class PncManagerImpl implements PncManager {
         try (var buildClient = new BuildClient(configuration)) {
             var brewComponent = buildClient.getSpecific(buildId).getAttributes().get("BREW_BUILD_NAME");
 
-            return new PncBuild(new PncBuild.Id(buildId), brewComponent);
+            return new PncBuild(new PncBuild.Id(buildId), new PncComponent(brewComponent));
         } catch (RemoteResourceException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/jboss/set/components/ManifestVerifierTest.java
+++ b/src/test/java/org/jboss/set/components/ManifestVerifierTest.java
@@ -1,0 +1,114 @@
+package org.jboss.set.components;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.set.components.pnc.PncArtifact;
+import org.jboss.set.components.pnc.PncBuild;
+import org.jboss.set.components.pnc.PncManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.wildfly.channel.ArtifactCoordinate;
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.channel.ChannelManifestMapper;
+import org.wildfly.channel.Stream;
+
+@ExtendWith(MockitoExtension.class)
+class ManifestVerifierTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    private PncManager pncManager;
+
+    @Test
+    public void differentComponentVersionsFromTheSameBuild_Warning() throws Exception {
+        final ManifestVerifier manifestVerifier = new ManifestVerifier(pncManager);
+        final PncArtifact pncArtifactOne = new PncArtifact(
+                new PncArtifact.Id("abcd"),
+                new ArtifactCoordinate("io.opentelemetry", "opentelemetry-context", "jar", null, "1.29.0"),
+                false);
+        final PncArtifact pncArtifactTwo = new PncArtifact(
+                new PncArtifact.Id("efgh"),
+                new ArtifactCoordinate("io.opentelemetry", "opentelemetry-semconv", "jar", null, "1.29.0.alpha"),
+                false);
+        final PncBuild pncBuild = new PncBuild(new PncBuild.Id("build_1"), "opentelementry");
+        when(pncManager.getArtifact(any())).thenReturn(pncArtifactOne);
+        when(pncManager.getBuildIdContainingArtifact(new PncArtifact.Id("abcd"))).thenReturn(pncBuild);
+        when(pncManager.getArtifactsInBuild(new PncBuild.Id("build_1"))).thenReturn(List.of(pncArtifactOne, pncArtifactTwo));
+
+        final ChannelManifest manifest = new ChannelManifest.Builder()
+                .setSchemaVersion(ChannelManifestMapper.SCHEMA_VERSION_1_1_0)
+                .addStreams(new Stream("io.opentelemetry", "opentelemetry-context", "1.29.0"))
+                .addStreams(new Stream("io.opentelemetry", "opentelemetry-semconv", "1.29.0.alpha"))
+                .build();
+        final Path manifestFile = tempDir.resolve("test-manifest.yaml");
+        Files.writeString(manifestFile, ChannelManifestMapper.toYaml(manifest));
+
+        final VerificationResult verificationResult = manifestVerifier.verifyComponents(manifestFile.toUri().toURL());
+
+        assertThat(verificationResult.getViolations()).isEmpty();
+        assertThat(verificationResult.getWarnings())
+                .map(Warning::getMessage)
+                .containsOnly("[WARN] Different versions of artifact from the same build:");
+    }
+
+    @Test
+    public void differentComponentVersionsFromTheDifferentBuild_Violation() throws Exception {
+        final ManifestVerifier manifestVerifier = new ManifestVerifier(pncManager);
+        final PncArtifact pncArtifactOneBuild1 = new PncArtifact(
+                new PncArtifact.Id("abcd1"),
+                new ArtifactCoordinate("io.opentelemetry", "opentelemetry-context", null, null, "1.29.0"),
+                false);
+        final PncArtifact pncArtifactTwoBuild1 = new PncArtifact(
+                new PncArtifact.Id("efgh1"),
+                new ArtifactCoordinate("io.opentelemetry", "opentelemetry-semconv", null, null, "1.29.0"),
+                false);
+        final PncArtifact pncArtifactOneBuild2 = new PncArtifact(
+                new PncArtifact.Id("abcd2"),
+                new ArtifactCoordinate("io.opentelemetry", "opentelemetry-context", null, null, "1.29.0.alpha"),
+                false);
+        final PncArtifact pncArtifactTwoBuild2 = new PncArtifact(
+                new PncArtifact.Id("efgh2"),
+                new ArtifactCoordinate("io.opentelemetry", "opentelemetry-semconv", null, null, "1.29.0.alpha"),
+                false);
+        final PncBuild pncBuildOne = new PncBuild(new PncBuild.Id("build_1"), "opentelemetry");
+        final PncBuild pncBuildTwo = new PncBuild(new PncBuild.Id("build_2"), "opentelemetry");
+        when(pncManager.getArtifact(pncArtifactOneBuild1.getCoordinate())).thenReturn(pncArtifactOneBuild1);
+        when(pncManager.getArtifact(pncArtifactTwoBuild2.getCoordinate())).thenReturn(pncArtifactTwoBuild2);
+        when(pncManager.getBuildIdContainingArtifact(new PncArtifact.Id("abcd1"))).thenReturn(pncBuildOne);
+        when(pncManager.getBuildIdContainingArtifact(new PncArtifact.Id("efgh2"))).thenReturn(pncBuildTwo);
+        when(pncManager.getArtifactsInBuild(new PncBuild.Id("build_1"))).thenReturn(List.of(pncArtifactOneBuild1, pncArtifactTwoBuild1));
+        when(pncManager.getArtifactsInBuild(new PncBuild.Id("build_2"))).thenReturn(List.of(pncArtifactOneBuild2, pncArtifactTwoBuild2));
+
+        final ChannelManifest manifest = new ChannelManifest.Builder()
+                .setSchemaVersion(ChannelManifestMapper.SCHEMA_VERSION_1_1_0)
+                .addStreams(new Stream("io.opentelemetry", "opentelemetry-context", "1.29.0"))
+                .addStreams(new Stream("io.opentelemetry", "opentelemetry-semconv", "1.29.0.alpha"))
+                .build();
+        final Path manifestFile = tempDir.resolve("test-manifest.yaml");
+        Files.writeString(manifestFile, ChannelManifestMapper.toYaml(manifest));
+
+        final VerificationResult verificationResult = manifestVerifier.verifyComponents(manifestFile.toUri().toURL());
+
+        assertThat(verificationResult.getWarnings()).isEmpty();
+        assertThat(verificationResult.getViolations())
+                .containsOnly(new Violation("opentelemetry", Map.of(
+                        "1.29.0", List.of(pncArtifactOneBuild1.getCoordinate()),
+                        "1.29.0.alpha", List.of(pncArtifactTwoBuild2.getCoordinate())
+                )));
+    }
+
+}

--- a/src/test/java/org/jboss/set/components/ManifestVerifierTest.java
+++ b/src/test/java/org/jboss/set/components/ManifestVerifierTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.jboss.set.components.pnc.PncArtifact;
 import org.jboss.set.components.pnc.PncBuild;
+import org.jboss.set.components.pnc.PncComponent;
 import org.jboss.set.components.pnc.PncManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,7 +45,7 @@ class ManifestVerifierTest {
                 new PncArtifact.Id("efgh"),
                 new ArtifactCoordinate("io.opentelemetry", "opentelemetry-semconv", "jar", null, "1.29.0.alpha"),
                 false);
-        final PncBuild pncBuild = new PncBuild(new PncBuild.Id("build_1"), "opentelementry");
+        final PncBuild pncBuild = new PncBuild(new PncBuild.Id("build_1"), new PncComponent("opentelementry"));
         when(pncManager.getArtifact(any())).thenReturn(pncArtifactOne);
         when(pncManager.getBuildIdContainingArtifact(new PncArtifact.Id("abcd"))).thenReturn(pncBuild);
         when(pncManager.getArtifactsInBuild(new PncBuild.Id("build_1"))).thenReturn(List.of(pncArtifactOne, pncArtifactTwo));
@@ -84,8 +85,8 @@ class ManifestVerifierTest {
                 new PncArtifact.Id("efgh2"),
                 new ArtifactCoordinate("io.opentelemetry", "opentelemetry-semconv", null, null, "1.29.0.alpha"),
                 false);
-        final PncBuild pncBuildOne = new PncBuild(new PncBuild.Id("build_1"), "opentelemetry");
-        final PncBuild pncBuildTwo = new PncBuild(new PncBuild.Id("build_2"), "opentelemetry");
+        final PncBuild pncBuildOne = new PncBuild(new PncBuild.Id("build_1"), new PncComponent("opentelemetry"));
+        final PncBuild pncBuildTwo = new PncBuild(new PncBuild.Id("build_2"), new PncComponent("opentelemetry"));
         when(pncManager.getArtifact(pncArtifactOneBuild1.getCoordinate())).thenReturn(pncArtifactOneBuild1);
         when(pncManager.getArtifact(pncArtifactTwoBuild2.getCoordinate())).thenReturn(pncArtifactTwoBuild2);
         when(pncManager.getBuildIdContainingArtifact(new PncArtifact.Id("abcd1"))).thenReturn(pncBuildOne);


### PR DESCRIPTION
Changes the logic to compare PNC build IDs for artifacts in the manifest rather than directly comparing their versions. 

A single PNC build can result in artifacts with different versions, which is fine (though should be reported). However including artifacts from multiple build IDs of the same component is not valid.

Issue: https://issues.redhat.com/browse/SET-870

